### PR TITLE
fix xquartz 2.7.8 download link

### DIFF
--- a/vsfm_os_x_installer.sh
+++ b/vsfm_os_x_installer.sh
@@ -173,7 +173,7 @@ echo "xquartz_version_result=$xquartz_version_result"
 if [ "$xquartz_version_result" != "0" ]
 then
 	echoBad "We must download the right version of XQuartz: $xquartz ... one moment while we install"
-	https://dl.bintray.com/xquartz/legacy-downloads/SL/XQuartz-$xquartz.dmg
+	wget https://dl.bintray.com/xquartz/legacy-downloads/SL/XQuartz-$xquartz.dmg
 	open XQuartz-$xquartz.dmg
 	echo "Switch to Finder and install XQuartz as per the installer. Then log in and out and then run script 2"
 else


### PR DESCRIPTION
seems to have moved from macosforge.org - to bintray.com
i'm not experienced in using git, please make sure I'm doing this right before I manage to break something! 