### PR TITLE
https://github.com/luckybulldozer/VisualSFM_OS_X_Installer/issues/34 …

### DIFF
--- a/patches/dpoint_err.patch
+++ b/patches/dpoint_err.patch
@@ -1,0 +1,13 @@
+--- program/base/stann/dpoint.hpp.orig	2016-12-30 16:46:41.000000000 +1030
++++ program/base/stann/dpoint.hpp	2016-12-30 16:49:39.000000000 +1030
+@@ -488,8 +488,8 @@
+ 	 for (int i=0; i<D; ++i)
+ 		 if(!(is >> p[i])){
+ 			 if(!is.eof()){
+-			   char errorpoint = is.getloc();
+-			   std::cerr << "Error Reading Point:" 
++			  streampos errorpoint = is.tellg(); 
++			  std::cerr << "Error Reading Point:" 
+ 				     << errorpoint << std::endl;
+ 				exit(1);
+ 			 }

--- a/vsfm_os_x_installer.sh
+++ b/vsfm_os_x_installer.sh
@@ -390,6 +390,7 @@ PMVS_SRC=https://github.com/pmoulon/CMVS-PMVS/archive/master.zip
     fi
 
 cd CMVS-PMVS-master/program
+patch base/stann/dpoint.hpp < ../../patches/dpoint_err.patch
 
 ####### CMakeLists.txt Patches
 	echo "Adding set CMAKE_EXE_LINKER_FLAGS -static-libgcc -static-libstdc++ to cmake flags"


### PR DESCRIPTION
…solution from https://github.com/abhvious

I guys it seems that CMVS PMVS2 was updated for a gcc6 compiler issue that made it incompatible with gcc4.9 that is used by this install, this patch smooths over that bug until the upstream issue is addressed.